### PR TITLE
VPC configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,21 +4,21 @@ terraform {
   required_version = "~> 0.11.8"
 }
 
-provider "aws" {
-  version = "~> 1.36.0"
-  region  = "${var.region}"
-}
+# VPC CONFIGURATION
+
+data "aws_availability_zones" "this" {}
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
   create_vpc = "${var.vpc-create}"
 
-  name = "${var.vpc-name}"
+  name = "${var.name}-vpc"
   cidr = "${var.vpc-cidr}"
-  azs  = "${local.vpc-azs}"
+  azs  = "${data.aws_availability_zones.this.names}"
 
-  public_subnets = "${var.vpc-public-subnets}"
+  public_subnets  = "${var.vpc-public-subnets}"
+  private_subnets = "${var.vpc-private-subnets}"
 
   # Every instance deployed within the VPC will get a hostname
   enable_dns_hostnames = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,44 +1,28 @@
 # Variables file
 
-## Provider variables
-variable "region" {
-  description = "AWS region where the entire infrastructure is deployed"
-  default     = "us-east-1"
+## Global variables
+
+variable "name" {
+  description = "Name to be used on all the resources as identifier"
 }
 
 ## VPC variables
-
-variable "vpc-region-azs" {
-  default = {
-    # N. Virginia
-    "us-east-1" = ["us-east-1a", "us-east-1b", "us-east-1c"]
-
-    # Ireland
-    "eu-west-1" = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  }
-}
 
 variable "vpc-create" {
   description = "Whether or not create a vpc using this module. If you have a preexisting VPC, just mark it as false"
   default     = true
 }
 
-variable "vpc-name" {
-  description = "Name to be used on all the resources as identifier"
-}
-
 variable "vpc-cidr" {
   default = "10.0.0.0/16"
 }
 
-locals {
-  # Here are selected the default AZs used for the subnets  # By default, a, b and c AZs are chosen and only supports  # US-EAST-1 🇺🇸 and EU-WEST-1 🇪🇺 regions, for now.
-
-  # 👎 We need to use locals becuase variables do not support interpolation
-  vpc-azs = "${var.vpc-region-azs["${var.region}"]}"
+variable "vpc-public-subnets" {
+  description = "List of public subnets to be used for the vpc"
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
-variable "vpc-public-subnets" {
-  description = "List of subnets to be used for the vpc"
-  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+variable "vpc-private-subnets" {
+  description = "List of private subnets to be used for the vpc"
+  default     = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 }


### PR DESCRIPTION
# VPC main configuration

This PR adds all the main configuration of the VPC used by the Fargate environment

- Reused [`terraform-aws-modules/vpc/aws`](https://github.com/terraform-aws-modules/terraform-aws-vpc) to easily create a basic configuration of a VPC for our needs

- This is kind of a sketch, probably we need to discuss better if we should add private subnets (or even infra subnets). Also, the module supports subnets for databases, probably we could use those. Let's discuss 😁
