### PR TITLE
Optional NAT gateway

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,11 @@ variable "vpc_private_subnets" {
   default     = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 }
 
+variable "vpc_create_nat" {
+  description = "Whether or not create a NAT gateway in the VPC managed by this module. Note that disabling this, it will forced to put ALL Fargate services inside a PUBLIC subnet with a PUBLIC ip address"
+  default     = true
+}
+
 ## LOGS
 
 variable "cloudwatch_logs_default_retention_days" {


### PR DESCRIPTION
This will allow the user to choose whether or not they want to create a NAT Gateway for the self-managed VPC. By default is true, so no breaking changes here.

One consideration is that if the user disables the creation of the NAT Gateway then, all the Fargate services will be placed in the public subnets + public IP address assigned to them.