### PR TITLE
App AutoScaling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The goal of this effort is to provide tools/configuration files/scripts/other to
 - [x] Send container logs to CloudWatch
 - [x] Basic health information in CloudWatch Logs/Metrics
 - [x] Optional NAT Gateway
+- [x] App Auto Scaling
 - [ ] Optional Application Load Balancer
-- [ ] Auto Scaling group
 - [ ] External Docker image deployment - No ECR registry for that service
 - [ ] Predefined alarms about container status
 - [ ] Predefined Docker images to simplify some aspects of deployment/runtime (ie. the image will be able to collect Node.js runtime metrics etc.)
@@ -51,6 +51,7 @@ The goal of this effort is to provide tools/configuration files/scripts/other to
 
 - [Basic][basic-usage]
 - [HTTPS enabled][https-usage]
+- [AutoScaling][autoscaling-usage]
 
 ## LICENSE
 
@@ -62,3 +63,4 @@ See the [LICENSE][license] file for information.
 [diagram]: diagram.png
 [basic-usage]: examples/basic
 [https-usage]: examples/https_enabled
+[autoscaling-usage]: examples/autoscaling

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -1,0 +1,29 @@
+# HTTPS enabled example
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Notice that the Auto Scaling configuration set by this module will be listening only to the [CPU average utilization metric](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html).
+
+If you want to configure Auto Scaling by using different metrics, you would need to set the Terraform resources [separately](https://www.terraform.io/docs/providers/aws/r/appautoscaling_policy.html).
+
+Note that this example create resources which can cost money (AWS Fargate Services, for example). Run `terraform destroy` when you don't need these resources.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc | VPC created for ECS cluster |
+| ecr | ECR Docker registry for Docker images |
+| ecs_cluster | ECS cluster |
+| application_load_balancers | ALBs which expose ECS services |
+| web_security_group | Security groups attached to ALBs |
+| services_security_groups | Security groups attached to ECS services |
+| cloudwatch_log_groups | CloudWatch groups for ECS services |

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = "~> 0.11.11"
+}
+
+provider "aws" {
+  version = "~> 1.54.0"
+  region  = "us-east-1"
+  profile = "playground"
+}
+
+module "fargate" {
+  source = "../../"
+
+  name = "autoscaling-example"
+
+  services = {
+    api = {
+      task_definition = "../basic/api.json"
+      container_port  = 3000
+      cpu             = "256"
+      memory          = "512"
+      replicas        = 3
+
+      auto_scaling_max_replicas     = 5  // Will scale out up to 5 replicas
+      auto_scaling_target_threshold = 60 // If Avg CPU Utilization reaches 60%, scale up operations gets triggered
+    }
+  }
+}

--- a/examples/autoscaling/outputs.tf
+++ b/examples/autoscaling/outputs.tf
@@ -1,0 +1,33 @@
+# VPC
+output "vpc" {
+  value = "${module.fargate.vpc}"
+}
+
+# ECR
+output "ecr" {
+  value = "${module.fargate.ecr_repository}"
+}
+
+# ECS Cluster
+output "ecs_cluster" {
+  value = "${module.fargate.ecs_cluster}"
+}
+
+# ALBs
+output "application_load_balancers" {
+  value = "${module.fargate.application_load_balancers}"
+}
+
+# Security Groups
+output "web_security_group" {
+  value = "${module.fargate.web_security_group}"
+}
+
+output "services_security_groups" {
+  value = "${module.fargate.services_security_groups}"
+}
+
+# CloudWatch
+output "cloudwatch_log_groups" {
+  value = "${module.fargate.cloudwatch_log_groups}"
+}

--- a/main.tf
+++ b/main.tf
@@ -274,6 +274,8 @@ resource "aws_appautoscaling_target" "this" {
   role_arn           = "${aws_iam_role.autoscaling.arn}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
+
+  depends_on = ["aws_ecs_service.this"]
 }
 
 resource "aws_appautoscaling_policy" "this" {

--- a/policies/appautoscaling-role-policy.json
+++ b/policies/appautoscaling-role-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "ecs:DescribeServices",
+              "ecs:UpdateService",
+              "cloudwatch:PutMetricAlarm",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:DeleteAlarms"
+          ],
+          "Resource": [
+              "*"
+          ]
+      }
+  ]
+}

--- a/policies/appautoscaling-role.json
+++ b/policies/appautoscaling-role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs.application-autoscaling.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}


### PR DESCRIPTION
This PR enables the possibility to have an Auto Scaling configuration by setting a maximum allowed replicas value and the CPU Utilization threshold that, once reached, triggers the autoscaling process.

So far it's only listening to CPU utilization metrics. There are other two default metrics available, Memory utilization and ALB requests count. If the user needs to support those (or any other custom metric), a separate TF resource can be created and attached to this module 👍 