### PR TITLE
Load Balancer health checks configuration

### DIFF
--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -7,3 +7,5 @@ const app = express()
 app.listen(3000, () => console.log(`Example app listening on port 3000! Host: ${hostname}`))
 
 app.get('/', async (req, res) => res.json({ hostname }))
+
+app.get('/health-check', async (req, res) => res.json({ message: 'I am healthy 💊' }))

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -24,7 +24,8 @@ module "fargate" {
       registry_retention_count = 15 # Optional. 20 by default
       logs_retention_days      = 14 # Optional. 30 by default
 
-      health_check_path = "/health-check" # Optional. "/" by default
+      health_check_interval = 100             # Optional. In seconds. 30 by default
+      health_check_path     = "/health-check" # Optional. "/" by default
     }
   }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,6 +23,8 @@ module "fargate" {
 
       registry_retention_count = 15 # Optional. 20 by default
       logs_retention_days      = 14 # Optional. 30 by default
+
+      health_check_path = "/health-check" # Optional. "/" by default
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,14 @@ resource "aws_lb_target_group" "this" {
   vpc_id      = "${module.vpc.vpc_id}"
   target_type = "ip"
 
+  health_check {
+    interval            = 20
+    path                = "${lookup(var.services[element(keys(var.services), count.index)], "health_check_path", var.alb_default_health_check_path)}"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "aws_lb_target_group" "this" {
   target_type = "ip"
 
   health_check {
-    interval            = 20
+    interval            = "${lookup(var.services[element(keys(var.services), count.index)], "health_check_interval", var.alb_default_health_check_interval)}"
     path                = "${lookup(var.services[element(keys(var.services), count.index)], "health_check_path", var.alb_default_health_check_path)}"
     healthy_threshold   = 3
     unhealthy_threshold = 3

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "services" {
   type = "map"
 }
 
+## ALB variables
+
+variable "alb_default_health_check_path" {
+  default = "/"
+}
+
 ## CODEPIPELINE SNS EVENTS varialbes
 
 variable "codepipeline_events_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,10 @@ variable "services" {
 
 ## ALB variables
 
+variable "alb_default_health_check_interval" {
+  default = 30
+}
+
 variable "alb_default_health_check_path" {
   default = "/"
 }


### PR DESCRIPTION
This feature adds the possibility to modify the default health check path for Load Balancer's target groups, which currently is `/`.  Now each service exposes the config value `health_check_path` to modify the default path value.

EDIT: Also, the check's interval has been added as configurable value (`health_check_interval`). By default, it is 30 seconds.

Closes: #20 