### PR TITLE
Upgrade TF and lock providers versions

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -13,4 +13,4 @@ exec docker run \
   --volume "$(cd .. && pwd)":/tmp/workspace/fargate-module \
   --env AWS_PROFILE="${AWS_PROFILE}" \
   --env AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}" \
-  hashicorp/terraform:0.11.11 "${@}"
+  hashicorp/terraform:0.11.13 "${@}"

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,18 @@ terraform {
   required_version = "~> 0.11.13"
 }
 
+provider "aws" {
+  version = "~> 2.6"
+}
+
+provider "random" {
+  version = "~> 2.1"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
 # VPC CONFIGURATION
 
 data "aws_availability_zones" "this" {}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Main Module file
 
 terraform {
-  required_version = "~> 0.11.11"
+  required_version = "~> 0.11.13"
 }
 
 # VPC CONFIGURATION
@@ -12,7 +12,7 @@ data "aws_region" "current" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "1.46.0"
+  version = "1.60.0"
 
   create_vpc = "${var.vpc_create}"
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 0.11.11"
+  required_version = "~> 0.11.13"
 }
 
 provider "aws" {
-  version = "~> 1.54.0"
+  version = "~> 2.6"
   profile = "test"
 }
 


### PR DESCRIPTION
This PR will upgrade the TF and VPC module to the last available stable versions.

Also, will lock the versions of the required providers: `aws`, `template` and `random`.