### PR TITLE
Default subnets ip ranges depending on chosen VPC CIDR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,25 @@ provider "template" {
 # VPC CONFIGURATION
 
 locals {
-  vpc_public_subnets  = "${split(",", length(var.vpc_public_subnets) > 0 ? join(",", var.vpc_public_subnets) : join(",", list(cidrsubnet(var.vpc_cidr, 8, 1), cidrsubnet(var.vpc_cidr, 8, 2), cidrsubnet(var.vpc_cidr, 8, 3))))}"
-  vpc_private_subnets = "${split(",", length(var.vpc_private_subnets) > 0 ? join(",", var.vpc_private_subnets) : join(",", list(cidrsubnet(var.vpc_cidr, 8, 101), cidrsubnet(var.vpc_cidr, 8, 102), cidrsubnet(var.vpc_cidr, 8, 103))))}"
+  vpc_public_subnets = "${split(",",
+    length(var.vpc_public_subnets) > 0
+    ? join(",", var.vpc_public_subnets)
+    : join(",", list(
+        cidrsubnet(var.vpc_cidr, 8, 1),
+        cidrsubnet(var.vpc_cidr, 8, 2),
+        cidrsubnet(var.vpc_cidr, 8, 3)
+      ))
+  )}"
+
+  vpc_private_subnets = "${split(",",
+    length(var.vpc_private_subnets) > 0
+    ? join(",", var.vpc_private_subnets)
+    : join(",", list(
+        cidrsubnet(var.vpc_cidr, 8, 101),
+        cidrsubnet(var.vpc_cidr, 8, 102),
+        cidrsubnet(var.vpc_cidr, 8, 103)
+      ))
+  )}"
 }
 
 data "aws_availability_zones" "this" {}

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,11 @@ provider "template" {
 
 # VPC CONFIGURATION
 
+locals {
+  vpc_public_subnets  = "${split(",", length(var.vpc_public_subnets) > 0 ? join(",", var.vpc_public_subnets) : join(",", list(cidrsubnet(var.vpc_cidr, 8, 1), cidrsubnet(var.vpc_cidr, 8, 2), cidrsubnet(var.vpc_cidr, 8, 3))))}"
+  vpc_private_subnets = "${split(",", length(var.vpc_private_subnets) > 0 ? join(",", var.vpc_private_subnets) : join(",", list(cidrsubnet(var.vpc_cidr, 8, 101), cidrsubnet(var.vpc_cidr, 8, 102), cidrsubnet(var.vpc_cidr, 8, 103))))}"
+}
+
 data "aws_availability_zones" "this" {}
 
 data "aws_region" "current" {}
@@ -28,8 +33,8 @@ module "vpc" {
   cidr = "${var.vpc_cidr}"
   azs  = "${data.aws_availability_zones.this.names}"
 
-  public_subnets  = "${var.vpc_public_subnets}"
-  private_subnets = "${var.vpc_private_subnets}"
+  public_subnets  = "${local.vpc_public_subnets}"
+  private_subnets = "${local.vpc_private_subnets}"
 
   # NAT gateway for private subnets
   enable_nat_gateway = "${var.vpc_create_nat}"

--- a/test/main.tf
+++ b/test/main.tf
@@ -16,6 +16,8 @@ module "fargate" {
 
   name = "${var.name}"
 
+  vpc_cidr = "10.1.0.0/16"
+
   services = {
     api = {
       task_definition = "api.json"

--- a/variables.tf
+++ b/variables.tf
@@ -24,12 +24,12 @@ variable "vpc_cidr" {
 
 variable "vpc_public_subnets" {
   description = "List of public subnets to be used for the vpc"
-  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  default     = []
 }
 
 variable "vpc_private_subnets" {
   description = "List of private subnets to be used for the vpc"
-  default     = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  default     = []
 }
 
 variable "vpc_create_nat" {


### PR DESCRIPTION
This change basically sets the default subnets IP ranges in a smarter way than before. Right now the default values are

- VPC `10.0.0.0/16`
- Subnets `10.0.1.0/24`, `10.0.2.0/24`, `10.0.3.0/24`, `10.0.101.0/24`, `10.0.102.0/24`, `10.0.103.0/24`

Which is ok, but if for some reason the user changes the VPC's CIDR, they'd be forced to change the subnets ones otherwise the module will fail.

With this change, the default for the subnets ranges depends on the VPC's one, using this amazing [function](https://www.terraform.io/docs/configuration-0-11/interpolation.html#cidrsubnet-iprange-newbits-netnum-) ❤️. Ofc, the user can update these values if required.