### PR TITLE
External VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The goal of this effort is to provide tools/configuration files/scripts/other to
 - [Basic][basic-usage]
 - [HTTPS enabled][https-usage]
 - [AutoScaling][autoscaling-usage]
+- [External VPC][external-vpc-usage]
 
 ## LICENSE
 
@@ -64,3 +65,4 @@ See the [LICENSE][license] file for information.
 [basic-usage]: examples/basic
 [https-usage]: examples/https_enabled
 [autoscaling-usage]: examples/autoscaling
+[external-vpc-usage]: examples/external_vpc

--- a/examples/external_vpc/README.md
+++ b/examples/external_vpc/README.md
@@ -1,0 +1,25 @@
+# External VPC example
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example create resources which can cost money (AWS Fargate Services, for example). Run `terraform destroy` when you don't need these resources.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc | VPC created for ECS cluster |
+| ecr | ECR Docker registry for Docker images |
+| ecs_cluster | ECS cluster |
+| application_load_balancers | ALBs which expose ECS services |
+| web_security_group | Security groups attached to ALBs |
+| services_security_groups | Security groups attached to ECS services |
+| cloudwatch_log_groups | CloudWatch groups for ECS services |

--- a/examples/external_vpc/api.json
+++ b/examples/external_vpc/api.json
@@ -1,0 +1,21 @@
+[
+  {
+    "portMappings": [
+      {
+        "hostPort": ${container_port},
+        "protocol": "tcp",
+        "containerPort": ${container_port}
+      }
+    ],
+    "image": "${repository_url}:latest",
+    "name": "${container_name}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  }
+]

--- a/examples/external_vpc/main.tf
+++ b/examples/external_vpc/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_version = ">= 0.11.13"
+}
+
+provider "aws" {
+  version = "~> 2.6.0"
+  region  = "us-east-1"
+  profile = "playground"
+}
+
+variable "public_subnets_cidrs" {
+  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_subnets_cidrs" {
+  default = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+}
+
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "1.60.0"
+
+  create_vpc = true
+
+  name = "the-external-vpc"
+  cidr = "10.0.0.0/16"
+  azs  = ["us-east-1a", "us-east-1b", "us-east-1c"]
+
+  public_subnets  = "${var.public_subnets_cidrs}"
+  private_subnets = "${var.private_subnets_cidrs}"
+}
+
+module "fargate" {
+  source = "../../"
+
+  name = "external-vpc-example"
+
+  vpc_create      = false                  # This variable must be set to false, otherwise the module will create its own VPC
+  vpc_external_id = "${module.vpc.vpc_id}"
+
+  vpc_public_subnets  = "${var.public_subnets_cidrs}"
+  vpc_private_subnets = "${var.private_subnets_cidrs}"
+
+  vpc_external_public_subnets_ids  = "${module.vpc.public_subnets}"
+  vpc_external_private_subnets_ids = "${module.vpc.private_subnets}"
+
+  services = {
+    api = {
+      task_definition = "api.json"
+      container_port  = 3000
+      cpu             = "256"
+      memory          = "512"
+      replicas        = 2
+    }
+  }
+}

--- a/examples/external_vpc/main.tf
+++ b/examples/external_vpc/main.tf
@@ -16,7 +16,6 @@ variable "private_subnets_cidrs" {
   default = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 }
 
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.60.0"

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,8 @@ variable "vpc_create" {
 }
 
 variable "vpc_cidr" {
-  default = "10.0.0.0/16"
+  description = "CIDR to be used for the VPC"
+  default     = "10.0.0.0/16"
 }
 
 variable "vpc_public_subnets" {
@@ -35,6 +36,23 @@ variable "vpc_private_subnets" {
 variable "vpc_create_nat" {
   description = "Whether or not create a NAT gateway in the VPC managed by this module. Note that disabling this, it will forced to put ALL Fargate services inside a PUBLIC subnet with a PUBLIC ip address"
   default     = true
+}
+
+## External VPC variables
+
+variable "vpc_external_id" {
+  description = "Id of the external VPC to be used. var.vpc_create must be false, otherwise, this variable will be ignored."
+  default     = ""
+}
+
+variable "vpc_external_public_subnets_ids" {
+  description = "Lists of ids of external public subnets. var.vpc_create must be false, otherwise, this variable will be ignored."
+  default     = []
+}
+
+variable "vpc_external_private_subnets_ids" {
+  description = "Lists of ids of external private subnets. var.vpc_create must be false, otherwise, this variable will be ignored."
+  default     = []
 }
 
 ## LOGS

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "vpc_create" {
 }
 
 variable "vpc_cidr" {
-  description = "CIDR to be used for the VPC"
+  description = "CIDR to be used by the VPC"
   default     = "10.0.0.0/16"
 }
 


### PR DESCRIPTION
This PR will allow the user to specify an already-created VPC to be used by the Fargate services. To activate this feature the user will need to provide the following variables:

- `vpc_create` as `false`, this prevents the creation of the internal VPC
- `vpc_external_id` which is the unique id of the external VPC that must exist under the user's AWS account
- `vpc_external_public_subnets_ids/vpc_external_private_subnets_ids` a list of ids for the public and private subnets, respectively. 