### PR TITLE
Cross Security Groups per Fargate service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The goal of this effort is to provide tools/configuration files/scripts/other to
 - [HTTPS enabled][https-usage]
 - [AutoScaling][autoscaling-usage]
 - [External VPC][external-vpc-usage]
+- [Cross security groups between services][cross-sg-services]
 
 ## LICENSE
 
@@ -68,4 +69,5 @@ See the [LICENSE][license] file for information.
 [https-usage]: examples/https_enabled
 [autoscaling-usage]: examples/autoscaling
 [external-vpc-usage]: examples/external_vpc
+[cross-sg-services]: examples/cross-sg-services
 [0.11-compatible]: https://github.com/strvcom/terraform-aws-fargate/tree/0.11.4

--- a/examples/cross-sg-services/README.md
+++ b/examples/cross-sg-services/README.md
@@ -1,0 +1,27 @@
+# Cross security groups example
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+`<service>.allow_connections_from` will enable incoming HTTP connections.
+
+Note that this example create resources which can cost money (AWS Fargate Services, for example). Run `terraform destroy` when you don't need these resources.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc | VPC created for ECS cluster |
+| ecr | ECR Docker registry for Docker images |
+| ecs_cluster | ECS cluster |
+| application_load_balancers | ALBs which expose ECS services |
+| web_security_group | Security groups attached to ALBs |
+| services_security_groups | Security groups attached to ECS services |
+| cloudwatch_log_groups | CloudWatch groups for ECS services |

--- a/examples/cross-sg-services/main.tf
+++ b/examples/cross-sg-services/main.tf
@@ -1,0 +1,39 @@
+# ⚠️ Only for TF version >=0.12
+
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "aws" {
+  version = "~> 2.12.0"
+  region  = "us-east-1"
+  profile = "playground"
+}
+
+module "fargate" {
+  source = "../../"
+
+  name = "cross-sg-example"
+
+  services = {
+    api = {
+      task_definition = "../basic/api.json"
+      container_port  = 3000
+      cpu             = "256"
+      memory          = "512"
+      replicas        = 3
+    }
+
+    api2 = {
+      task_definition = "../basic/api.json" # Does not need to be the same service ofc
+      container_port  = 3000
+      cpu             = "512"
+      memory          = "1024"
+      replicas        = 1
+
+      # To explicitly allow connections from one service to another, use this label "allow_connections_from: array[string]"
+      # Service "api" will be able to reach "api2" thru HTTP
+      allow_connections_from = ["api"]
+    }
+  }
+}

--- a/examples/cross-sg-services/outputs.tf
+++ b/examples/cross-sg-services/outputs.tf
@@ -1,0 +1,33 @@
+# VPC
+output "vpc" {
+  value = "${module.fargate.vpc}"
+}
+
+# ECR
+output "ecr" {
+  value = "${module.fargate.ecr_repository}"
+}
+
+# ECS Cluster
+output "ecs_cluster" {
+  value = "${module.fargate.ecs_cluster}"
+}
+
+# ALBs
+output "application_load_balancers" {
+  value = "${module.fargate.application_load_balancers}"
+}
+
+# Security Groups
+output "web_security_group" {
+  value = "${module.fargate.web_security_group}"
+}
+
+output "services_security_groups" {
+  value = "${module.fargate.services_security_groups}"
+}
+
+# CloudWatch
+output "cloudwatch_log_groups" {
+  value = "${module.fargate.cloudwatch_log_groups}"
+}

--- a/main.tf
+++ b/main.tf
@@ -322,8 +322,8 @@ resource "aws_ecs_service" "this" {
 
   network_configuration {
     security_groups = [
-      aws_security_group.services[count.index].id, count.index,
-      aws_security_group.services_dynamic[count.index].id, count.index
+      aws_security_group.services[count.index].id,
+      aws_security_group.services_dynamic[count.index].id
     ]
 
     subnets          = var.vpc_create_nat ? local.vpc_private_subnets_ids : local.vpc_public_subnets_ids

--- a/variables.tf
+++ b/variables.tf
@@ -67,9 +67,7 @@ variable "ecr_default_retention_count" {
   default = 20
 }
 
-variable "services" {
-  type = "map"
-}
+variable "services" {}
 
 ## ALB variables
 


### PR DESCRIPTION
This PR will enable the possibility to add cross connectivity between Fargate services by using dynamic Security Groups.

- field added: `<service>.allow_connections_from` `array[string]`

Closes: #13 