### PR TITLE
Fargate Service Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ module "fargate" {
       auto_scaling_max_cpu_util = 60 # Number, Optional: the avg CPU utilization needed to trigger a auto scaling operation
 
       allow_connections_from = ["api2"] # List[String], Optional: By default all services can only accept connections from their ALB. To explicitly allow connections from one service to another, use this label. This means that THIS service can be reached by service `api2`
+
+      service_discovery_enabled = true # Boolean, Optional: enables service discovery by creating a private Route53 zone. <service_name>.<cluster_name>.<terraform_workspace>.local
     }
 
     another_service = {

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ locals {
   services_count = length(var.services)
 
   # ⚠️ remove when https://github.com/hashicorp/terraform/issues/22560 gets fixed
-  services_with_sd = [for s in local.services : s if lookup(s, "enable_service_discovery", false)]
+  services_with_sd = [for s in local.services : s if lookup(s, "service_discovery_enabled", false)]
 }
 
 data "aws_availability_zones" "this" {}
@@ -305,7 +305,7 @@ resource "aws_lb_listener" "this" {
 # SERVICE DISCOVERY
 
 resource "aws_service_discovery_private_dns_namespace" "this" {
-  count = length([for s in local.services : s if lookup(s, "enable_service_discovery", false)]) > 0 ? 1 : 0
+  count = length([for s in local.services : s if lookup(s, "service_discovery_enabled", false)]) > 0 ? 1 : 0
 
   name        = "${var.name}.${terraform.workspace}.local"
   description = "${var.name} private dns namespace"
@@ -314,7 +314,7 @@ resource "aws_service_discovery_private_dns_namespace" "this" {
 
 resource "aws_service_discovery_service" "this" {
   # ⚠️ replace when https://github.com/hashicorp/terraform/issues/22560 gets fixed
-  # for_each = [for s in local.services : s if lookup(s, "enable_service_discovery", false)]
+  # for_each = [for s in local.services : s if lookup(s, "service_discovery_enabled", false)]
   count = length(local.services_with_sd) > 0 ? length(local.services_with_sd) : 0
 
   # name = each.value.name


### PR DESCRIPTION
Now each Fargate service can be addressed via Route53 private namespaces to allow Service Discovery.

The DNS name for each service will be in the form of: 
```
<service_name>.<cluster_name>.<terraform_workspace>.local
```

Eg. API service under Test cluster in the Production environment can be reached using `api.test.production.local.` A record.