### PR TITLE
Expose Fargate task definition IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,7 @@ resource "aws_ecs_task_definition" "this" {
   cpu                      = local.services[count.index].cpu
   memory                   = local.services[count.index].memory
   execution_role_arn       = aws_iam_role.tasks.arn
-  task_role_arn            = aws_iam_role.tasks.arn
+  task_role_arn            = lookup(local.services[count.index], "task_role_arn", null)
 }
 
 data "aws_ecs_task_definition" "this" {


### PR DESCRIPTION
This PR allows the user to set and attach a custom IAM role to the Fargate task. Currently, it is duplicated pointing to the same IAM used for execution (logs, ECR image pulls) which is pointless. 😄 