### PR TITLE
Allow to provide task_definition_template_vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,13 +130,13 @@ data "template_file" "tasks" {
 
   template = file("${path.cwd}/${local.services[count.index].task_definition}")
 
-  vars = {
+  vars = merge({
     container_name = local.services[count.index].name
     container_port = local.services[count.index].container_port
     repository_url = aws_ecr_repository.this[count.index].repository_url
     log_group      = aws_cloudwatch_log_group.this[count.index].name
     region         = var.region != "" ? var.region : data.aws_region.current.name
-  }
+  }, lookup(local.services[count.index], "task_definition_template_vars", {}))
 }
 
 resource "aws_ecs_task_definition" "this" {


### PR DESCRIPTION
This pull request adds `task_definition_template_vars` (`map(string)`) to the service definition.
Doing so, we can pass / or overwrite template variables of the task definition template file.

I needed this to inject secrets and other environment variables into my task definition.

Example:

```terraform
  services = {
    api = {
      task_definition = "fargate/backend.json"
      task_definition_template_vars = {
        aws_ssm_database_url = aws_ssm_parameter.aws_ssm_database_url.arn
        aws_ssm_secret_key_base = aws_ssm_parameter.aws_ssm_secret_key_base.arn
        aws_ssm_guardian_secret_key = aws_ssm_parameter.aws_ssm_guardian_secret_key.arn
        public_dns = "<redacted>"
      }
```

And in `fargate/backend.json`:

```json
[
  {
    "portMappings": [
      {
        "hostPort": ${container_port},
        "protocol": "tcp",
        "containerPort": ${container_port}
      }
    ],
    "image": "${repository_url}:latest",
    "name": "${container_name}",
    "logConfiguration": {
      "logDriver": "awslogs",
      "options": {
        "awslogs-group": "${log_group}",
        "awslogs-region": "${region}",
        "awslogs-stream-prefix": "ecs"
      }
    },
    "environment": [
      { "name": "PUBLIC_DNS", "value": "${public_dns}" }
    ],
    "secrets": [
      { "name": "DATABASE_URL", "valueFrom": "${aws_ssm_database_url}" },
      { "name": "SECRET_KEY_BASE", "valueFrom": "${aws_ssm_secret_key_base}" },
      { "name": "GUARDIAN_SECRET_KEY", "valueFrom": "${aws_ssm_guardian_secret_key}" }
    ]
  }
]
```
