### PR TITLE
Extend the task execution policy document to enable AWS SSM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ module "fargate" {
 
   codepipeline_events_enabled = true # Boolean, Optional: sns topic that exposes codepipeline events such as STARTED, FAILED, SUCCEEDED, CANCELED for new deployments. default = false.
 
+  ssm_allowed_parameters = "backend_*" # String, Optional: SSM parameter prefix. Allows the tasks to pull and use SSM parameters during task bootstrap. In case of requiring parameters from a different region, specify the full ARN string.
+
   services = { # Map, Required: the main object containing all information regarding fargate services
     name_of_your_service = { # Map, Required at least one: object containing specs of a specific Fargate service.
       task_definition = "api.json" # String, Required: string matching a valid ECS Task definition json file. This is a relative path ⚠️.

--- a/policies/ecs-task-execution-role-policy-ssm.json
+++ b/policies/ecs-task-execution-role-policy-ssm.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "ssm:GetParameters"
+          ],
+          "Resource": ["${ssm_parameters_arn}"]
+      }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,11 @@ variable "ecr_default_retention_count" {
 
 variable "services" {}
 
+variable "ssm_allowed_parameters" {
+  description = "List of ssm parameters that can be acceesed by the Fargate task during execution. Could be an ARN or just the name of the parameter path prefix"
+  default     = ""
+}
+
 ## ALB variables
 
 variable "alb_default_health_check_interval" {


### PR DESCRIPTION
100% inspired by #47. Thx @Overbryd 
 
> Note: I create a different PR because of CI and encrypted credentials ⚠️🙏