### PR TITLE
Update ECR event mapping

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -13,4 +13,4 @@ exec docker run \
   --volume "$(cd .. && pwd)":/tmp/workspace/fargate-module \
   --env AWS_PROFILE="${AWS_PROFILE}" \
   --env AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}" \
-  hashicorp/terraform:0.12.8 "${@}"
+  hashicorp/terraform:0.12.15 "${@}"

--- a/cloudwatch/ecr-source-event.json
+++ b/cloudwatch/ecr-source-event.json
@@ -3,22 +3,17 @@
     "aws.ecr"
   ],
   "detail-type": [
-    "AWS API Call via CloudTrail"
+    "ECR Image Action"
   ],
   "detail": {
-    "eventSource": [
-      "ecr.amazonaws.com"
+    "action-type": [
+      "PUSH"
     ],
-    "eventName": [
-      "PutImage"
+    "image-tag": [
+      "latest"
     ],
-    "requestParameters": {
-      "repositoryName": [
-        "${ecr_repository_name}"
-      ],
-      "imageTag": [
-        "latest"
-      ]
-    }
+    "repository-name": [
+      "${ecr_repository_name}"
+    ]
   }
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -14,7 +14,7 @@ module "fargate" {
 
   vpc_create_nat = false
 
-  name = "${var.name}"
+  name = var.name
 
   vpc_cidr = "10.1.0.0/16"
 


### PR DESCRIPTION
Currently, the ECR events on Cloudwatch are being fetched from CloudTrail instead of the service directly.

Now direct ECR events are supported 🚀No need of CloudTrail anymore.