### PR TITLE
Optionally configure internal service via its load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ module "fargate" {
       cpu             = "256" # String, Required: CPU units used by the tasks
       memory          = "512" # String, Required: memory used by the tasks
       replicas        = 5 # Number, Required: amount of task replicas needed for the ecs service
+      internal        = false # Boolean, Optional: allows to specify that the service will live in a private subnet and use an internal load balancer
 
       registry_retention_count = 15 # Number, Optional: sets how many images does the ecr registry will retain before recycling old ones. default = 20
       logs_retention_days      = 14 # Number, Optional: sets how many days does the cloud watch log group will retain logs entries before deleting old ones. default = 30

--- a/main.tf
+++ b/main.tf
@@ -283,9 +283,10 @@ resource "aws_lb_target_group" "this" {
 
 resource "aws_lb" "this" {
   count = local.services_count > 0 ? local.services_count : 0
+  internal        = lookup(local.services[count.index], "internal", false)
 
   name            = "${var.name}-${terraform.workspace}-${local.services[count.index].name}-alb"
-  subnets         = slice(local.vpc_public_subnets_ids, 0, min(length(data.aws_availability_zones.this.names), length(local.vpc_public_subnets_ids)))
+  subnets         = lookup(local.services[count.index], "internal", false) ? slice(local.vpc_private_subnets_ids, 0, min(length(data.aws_availability_zones.this.names), length(local.vpc_private_subnets_ids))) : slice(local.vpc_public_subnets_ids, 0, min(length(data.aws_availability_zones.this.names), length(local.vpc_public_subnets_ids)))
   security_groups = [aws_security_group.web.id]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -282,8 +282,8 @@ resource "aws_lb_target_group" "this" {
 }
 
 resource "aws_lb" "this" {
-  count = local.services_count > 0 ? local.services_count : 0
-  internal        = lookup(local.services[count.index], "internal", false)
+  count    = local.services_count > 0 ? local.services_count : 0
+  internal = lookup(local.services[count.index], "internal", false)
 
   name            = "${var.name}-${terraform.workspace}-${local.services[count.index].name}-alb"
   subnets         = lookup(local.services[count.index], "internal", false) ? slice(local.vpc_private_subnets_ids, 0, min(length(data.aws_availability_zones.this.names), length(local.vpc_private_subnets_ids))) : slice(local.vpc_public_subnets_ids, 0, min(length(data.aws_availability_zones.this.names), length(local.vpc_public_subnets_ids)))


### PR DESCRIPTION
This PR adds the option to configure a service that's not internet facing.
It will use an internal load balancer instead of internet facing, living in the private subnets instead of public ones