### PR TITLE
Add support for dynamic intra-service ingress and configurable auto-scaling

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -68,6 +68,11 @@ output "application_load_balancers_dns_names" {
   value       = aws_lb.this.*.dns_name
 }
 
+output "application_load_balancers_listeners_arns" {
+  description = "List of ARNs of Application Load Balancer Listeners"
+  value       = aws_lb_listener.this.*.arn
+}
+
 # SECURITY GROUPS
 
 output "web_security_group_arn" {


### PR DESCRIPTION
Example:
```
[...]
myService = {
  [...]
  ingress_ports   = [5701, 15701] # vert.x hazelcast cluster
  container_port  = 80
  auto_scaling_metric_type = "ALBRequestCountPerTarget"
  auto_scaling_target_value = 200
  [...]
}
[...]
```